### PR TITLE
CMO-24 Cognito using non approved software,

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "babel-polyfill": "6.23.0",
     "babel-preset-env": "1.6.0",
     "babel-preset-react": "6.24.1",
-    "browser-sync": "2.18.12",
+    "browser-sync": "2.26.7",
     "chalk": "2.0.1",
     "concurrently": "3.5.0",
     "connect-history-api-fallback": "1.3.0",


### PR DESCRIPTION
## Description
The Cognito service is using an non- approved software called "varnish" as part of code.
https://varnish-cache.org/ , removing references to varnish by upgrading browser-sync

## Jira Issue link
<!--- Provide the link to Jira -->
[Cognito using non approved software](https://osi-cwds.atlassian.net/browse/CMO-24)
